### PR TITLE
Add RODNEY_HOME env var to support custom state directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,11 +309,12 @@ This pattern is useful in CI — run Rodney as a post-deploy check, an accessibi
 
 | Environment Variable | Default | Description |
 |---|---|---|
+| `RODNEY_HOME` | `~/.rodney` | Data directory for state and Chrome profile |
 | `ROD_CHROME_BIN` | `/usr/bin/google-chrome` | Path to Chrome/Chromium binary |
 | `ROD_TIMEOUT` | `30` | Default timeout in seconds for element queries |
 | `HTTPS_PROXY` / `HTTP_PROXY` | (none) | Authenticated proxy auto-detected on start |
 
-Global state is stored in `~/.rodney/state.json` with Chrome user data in `~/.rodney/chrome-data/`. When using `--local`, state is stored in `./.rodney/state.json` and `./.rodney/chrome-data/` in the current directory instead.
+Global state is stored in `~/.rodney/state.json` with Chrome user data in `~/.rodney/chrome-data/`. When using `--local`, state is stored in `./.rodney/state.json` and `./.rodney/chrome-data/` in the current directory instead. Set `RODNEY_HOME` to override the default global directory.
 
 ## Proxy support
 

--- a/help.txt
+++ b/help.txt
@@ -70,6 +70,9 @@ By default, commands auto-detect: if ./.rodney/state.json exists in the
 current directory, the local session is used; otherwise the global session.
 Use "rodney start --local" to create a directory-scoped session.
 
+Environment:
+  RODNEY_HOME                     Override data directory (default: ~/.rodney)
+
 Exit codes:
   0  Success
   1  Check failed (exists, visible, ax-find returned no match)

--- a/main.go
+++ b/main.go
@@ -87,10 +87,12 @@ type State struct {
 }
 
 func stateDir() string {
+	if dir := os.Getenv("RODNEY_HOME"); dir != "" {
+		return dir
+	}
 	if activeStateDir != "" {
 		return activeStateDir
 	}
-	// Fallback for when activeStateDir hasn't been set (e.g. tests)
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".rodney")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -729,6 +729,29 @@ func TestResolveStateDir_LocalUsesWorkingDir(t *testing.T) {
 	}
 }
 
+// =====================
+// RODNEY_HOME env var tests
+// =====================
+
+func TestStateDir_Default(t *testing.T) {
+	t.Setenv("RODNEY_HOME", "")
+	home, _ := os.UserHomeDir()
+	want := home + "/.rodney"
+	got := stateDir()
+	if got != want {
+		t.Errorf("stateDir() = %q, want %q", got, want)
+	}
+}
+
+func TestStateDir_EnvVar(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RODNEY_HOME", dir)
+	got := stateDir()
+	if got != dir {
+		t.Errorf("stateDir() = %q, want %q", got, dir)
+	}
+}
+
 func TestMimeToExt(t *testing.T) {
 	tests := []struct {
 		mime string


### PR DESCRIPTION
Adds `RODNEY_HOME` environment variable to customize the state directory, instead of it being hardcoded to `~/.rodney`.

This is a potential solution for #6 that could support per-project, or temporary, state directories, while imposing no overhead/impact for users that don't need it.

I choose env variable as the mechanism because there are already some env vars that control how the binary works (`ROD_CHROME_BIN`, `HTTPS_PROXY`), and the documented CLI flags (eg. for accessibility testing) seem to be subcommand-specific.

Designed and developed using Claude Code (Opus 4.6), I personally reviewed the output and tested it locally before submitting this PR.

This is the complete plan Claude implemented:

---
# Add `RODNEY_HOME` environment variable

## Context

The rodney data directory (`~/.rodney/`) is hard-coded via the `stateDir()` function in `main.go:41-44`. There is no way to customize it, which blocks per-project or multi-session usage (see GitHub issue #6). We'll add a `RODNEY_HOME` env var to allow overriding the directory.

## Changes

### 1. `rodney-src/main.go` (lines 41-44)

Replace the current `stateDir()` with a minimal version that checks `RODNEY_HOME` first:

```go
func stateDir() string {
    if dir := os.Getenv("RODNEY_HOME"); dir != "" {
        return dir
    }
    home, _ := os.UserHomeDir()
    return filepath.Join(home, ".rodney")
}
```

No validation or directory creation here — `saveState()` (line 63) and `cmdStart()` (line 262-263) already call `os.MkdirAll` on the returned path.

### 2. `rodney-src/main_test.go`

Add tests (no browser needed — pure function tests):

- **`TestStateDir_Default`** — unset `RODNEY_HOME`, verify `stateDir()` returns `$HOME/.rodney`
- **`TestStateDir_EnvVar`** — set `RODNEY_HOME` to a temp dir, verify `stateDir()` returns it

### 3. `rodney-src/help.txt`

Add `RODNEY_HOME` to the configuration/environment section.

### 4. `rodney-src/README.md`

Add `RODNEY_HOME` to the configuration table.

## Verification

1. Run tests: `cd rodney-src && go test -run TestStateDir -v`
2. Build: `go build -o rodney .`
3. Manual smoke test: `RODNEY_HOME=/tmp/rodney-test ./rodney start && ls /tmp/rodney-test/ && RODNEY_HOME=/tmp/rodney-test ./rodney stop`