### PR TITLE
Add a "rodney start --show" option

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -1,7 +1,7 @@
 rodney - Chrome automation from the command line
 
 Browser lifecycle:
-  rodney start                    Launch headless Chrome
+  rodney start [--show]           Launch Chrome (headless by default, --show for visible)
   rodney stop                     Shut down Chrome
   rodney status                   Show browser status
 

--- a/main.go
+++ b/main.go
@@ -259,6 +259,14 @@ func cmdStart(args []string) {
 		}
 	}
 
+	// Parse flags
+	headless := true
+	for _, arg := range args {
+		if arg == "--show" {
+			headless = false
+		}
+	}
+
 	dataDir := filepath.Join(stateDir(), "chrome-data")
 	os.MkdirAll(dataDir, 0755)
 
@@ -266,9 +274,15 @@ func cmdStart(args []string) {
 		Set("no-sandbox").
 		Set("disable-gpu").
 		Set("single-process"). // Required for screenshots in gVisor/container environments
-		Headless(true).
-		Leakless(false). // Keep Chrome alive after CLI exits
-		UserDataDir(dataDir)
+		Leakless(false).        // Keep Chrome alive after CLI exits
+		UserDataDir(dataDir).
+		Headless(headless)
+
+	// When in non-headless mode, make sure that we show the startup window immediately
+	// (instead of showing a window only after calling "rodney open")
+	if !headless {
+		l = l.Delete("no-startup-window")
+	}
 
 	if bin := os.Getenv("ROD_CHROME_BIN"); bin != "" {
 		l = l.Bin(bin)


### PR DESCRIPTION
This makes it possible to start chrome in "headed" mode. I find it useful to develop scripts manually and to be able to follow what agents do.

I'm not 100% sure about the name of the option; other possible alternatives are:
  - `rodney start --visible`
  - `rodney start --window`
  - `rodney start --headed`
  - `rodney start --no-headless`

**AI disclaimer**: ~90% of the code was written by claude, but I reviewed it personally. Comments are mine.