### PR TITLE
Fix `rodney start --show` flag parsing bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -318,16 +318,33 @@ func withPage() (*State, *rod.Browser, *rod.Page) {
 
 // --- Commands ---
 
-func cmdStart(args []string) {
-	ignoreCertErrors := false
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
+type startFlags struct {
+	headless         bool
+	ignoreCertErrors bool
+}
+
+// parseStartFlags parses the arguments to "rodney start".
+func parseStartFlags(args []string) (startFlags, error) {
+	f := startFlags{headless: true}
+	for _, arg := range args {
+		switch arg {
+		case "--show":
+			f.headless = false
 		case "--insecure", "-k":
-			ignoreCertErrors = true
+			f.ignoreCertErrors = true
 		default:
-			fatal("unknown flag: %s\nusage: rodney start [--insecure]", args[i])
+			return f, fmt.Errorf("unknown flag: %s\nusage: rodney start [--show] [--insecure]", arg)
 		}
 	}
+	return f, nil
+}
+
+func cmdStart(args []string) {
+	flags, err := parseStartFlags(args)
+	if err != nil {
+		fatal("%s", err)
+	}
+	ignoreCertErrors := flags.ignoreCertErrors
 
 	// Check if already running
 	if s, err := loadState(); err == nil {
@@ -339,13 +356,7 @@ func cmdStart(args []string) {
 		}
 	}
 
-	// Parse flags
-	headless := true
-	for _, arg := range args {
-		if arg == "--show" {
-			headless = false
-		}
-	}
+	headless := flags.headless
 
 	dataDir := filepath.Join(stateDir(), "chrome-data")
 	os.MkdirAll(dataDir, 0755)

--- a/main.go
+++ b/main.go
@@ -333,7 +333,7 @@ func parseStartFlags(args []string) (startFlags, error) {
 		case "--insecure", "-k":
 			f.ignoreCertErrors = true
 		default:
-			return f, fmt.Errorf("unknown flag: %s\nusage: rodney start [--show] [--insecure]", arg)
+			return f, fmt.Errorf("unknown flag: %s\nusage: rodney start [--show] [--insecure | -k]", arg)
 		}
 	}
 	return f, nil

--- a/main_test.go
+++ b/main_test.go
@@ -1148,3 +1148,76 @@ func TestInsecureFlag_WithSelfSignedCert(t *testing.T) {
 		}
 	})
 }
+
+// =====================
+// parseStartFlags tests
+// =====================
+
+func TestParseStartFlags_ShowFlag(t *testing.T) {
+	flags, err := parseStartFlags([]string{"--show"})
+	if err != nil {
+		t.Fatalf("--show should be accepted, got error: %v", err)
+	}
+	if flags.headless {
+		t.Error("expected headless=false when --show is passed")
+	}
+}
+
+func TestParseStartFlags_ShowAndInsecure(t *testing.T) {
+	flags, err := parseStartFlags([]string{"--show", "--insecure"})
+	if err != nil {
+		t.Fatalf("--show --insecure should be accepted, got error: %v", err)
+	}
+	if flags.headless {
+		t.Error("expected headless=false when --show is passed")
+	}
+	if !flags.ignoreCertErrors {
+		t.Error("expected ignoreCertErrors=true when --insecure is passed")
+	}
+}
+
+func TestParseStartFlags_InsecureOnly(t *testing.T) {
+	flags, err := parseStartFlags([]string{"--insecure"})
+	if err != nil {
+		t.Fatalf("--insecure should be accepted, got error: %v", err)
+	}
+	if !flags.headless {
+		t.Error("expected headless=true (default) when --show is not passed")
+	}
+	if !flags.ignoreCertErrors {
+		t.Error("expected ignoreCertErrors=true when --insecure is passed")
+	}
+}
+
+func TestParseStartFlags_KShorthand(t *testing.T) {
+	flags, err := parseStartFlags([]string{"-k"})
+	if err != nil {
+		t.Fatalf("-k should be accepted, got error: %v", err)
+	}
+	if !flags.ignoreCertErrors {
+		t.Error("expected ignoreCertErrors=true when -k is passed")
+	}
+}
+
+func TestParseStartFlags_NoArgs(t *testing.T) {
+	flags, err := parseStartFlags([]string{})
+	if err != nil {
+		t.Fatalf("no args should be accepted, got error: %v", err)
+	}
+	if !flags.headless {
+		t.Error("expected headless=true by default")
+	}
+	if flags.ignoreCertErrors {
+		t.Error("expected ignoreCertErrors=false by default")
+	}
+}
+
+func TestParseStartFlags_UnknownFlag(t *testing.T) {
+	_, err := parseStartFlags([]string{"--bogus"})
+	if err == nil {
+		t.Fatal("expected error for unknown flag --bogus")
+	}
+	if !strings.Contains(err.Error(), "unknown flag: --bogus") {
+		t.Errorf("expected 'unknown flag: --bogus' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug**: `rodney start --show` failed with `unknown flag: --show` because the argument parser had two sequential loops — the first rejected `--show` before the second (which handled it) could run
- **Fix**: Extract `parseStartFlags()` with a single merged switch statement
- **Tests**: 6 new unit tests covering `--show`, `--show --insecure`, `--insecure`, `-k`, no args, and unknown flags

Fixes #23

## Demo

The `--show` flag for `rodney start` was documented in help.txt but broken — the argument parser rejected it as an unknown flag before reaching the code that handled it. Two sequential loops: the first validated flags (only knew `--insecure`/`-k`) and called `fatal()` on anything else; the second set `headless=false` for `--show` but was dead code.

The fix extracts flag parsing into a testable `parseStartFlags` function and merges both loops into a single switch statement. Six new tests cover `--show` alone, `--show --insecure` together, `--insecure` only, `-k` shorthand, no args, and unknown flags.

```bash
git diff main -- main.go
```

```
diff --git a/main.go b/main.go
index 0b2531a..79bb8a6 100644
--- a/main.go
+++ b/main.go
@@ -318,16 +318,33 @@ func withPage() (*State, *rod.Browser, *rod.Page) {
 
 // --- Commands ---
 
-func cmdStart(args []string) {
-	ignoreCertErrors := false
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
+type startFlags struct {
+	headless         bool
+	ignoreCertErrors bool
+}
+
+// parseStartFlags parses the arguments to "rodney start".
+func parseStartFlags(args []string) (startFlags, error) {
+	f := startFlags{headless: true}
+	for _, arg := range args {
+		switch arg {
+		case "--show":
+			f.headless = false
 		case "--insecure", "-k":
-			ignoreCertErrors = true
+			f.ignoreCertErrors = true
 		default:
-			fatal("unknown flag: %s\nusage: rodney start [--insecure]", args[i])
+			return f, fmt.Errorf("unknown flag: %s\nusage: rodney start [--show] [--insecure]", arg)
 		}
 	}
+	return f, nil
+}
+
+func cmdStart(args []string) {
+	flags, err := parseStartFlags(args)
+	if err != nil {
+		fatal("%s", err)
+	}
+	ignoreCertErrors := flags.ignoreCertErrors
 
 	// Check if already running
 	if s, err := loadState(); err == nil {
@@ -339,13 +356,7 @@ func cmdStart(args []string) {
 		}
 	}
 
-	// Parse flags
-	headless := true
-	for _, arg := range args {
-		if arg == "--show" {
-			headless = false
-		}
-	}
+	headless := flags.headless
 
 	dataDir := filepath.Join(stateDir(), "chrome-data")
 	os.MkdirAll(dataDir, 0755)
```

```bash
go test -run TestParseStartFlags -v
```

```
=== RUN   TestParseStartFlags_ShowFlag
--- PASS: TestParseStartFlags_ShowFlag (0.00s)
=== RUN   TestParseStartFlags_ShowAndInsecure
--- PASS: TestParseStartFlags_ShowAndInsecure (0.00s)
=== RUN   TestParseStartFlags_InsecureOnly
--- PASS: TestParseStartFlags_InsecureOnly (0.00s)
=== RUN   TestParseStartFlags_KShorthand
--- PASS: TestParseStartFlags_KShorthand (0.00s)
=== RUN   TestParseStartFlags_NoArgs
--- PASS: TestParseStartFlags_NoArgs (0.00s)
=== RUN   TestParseStartFlags_UnknownFlag
--- PASS: TestParseStartFlags_UnknownFlag (0.00s)
PASS
```

All 6 new tests pass. The full suite (65 tests) also passes with no regressions.

## Test plan

- [x] `TestParseStartFlags_ShowFlag` — `--show` alone sets headless=false
- [x] `TestParseStartFlags_ShowAndInsecure` — both flags work together
- [x] `TestParseStartFlags_InsecureOnly` — `--insecure` regression test
- [x] `TestParseStartFlags_KShorthand` — `-k` regression test
- [x] `TestParseStartFlags_NoArgs` — defaults are correct
- [x] `TestParseStartFlags_UnknownFlag` — unknown flags still rejected
- [x] Full test suite (65 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)