### PR TITLE
Add fake media flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Requires:
 rodney start              # Launch headless Chrome
 rodney start --show       # Launch with visible browser window
 rodney start --insecure   # Launch with TLS errors ignored (-k shorthand)
+rodney start --fake-media # Launch with fake media devices (avoids getUserMedia crashes)
 rodney connect host:9222  # Connect to existing Chrome on remote debug port
 rodney status             # Show browser info and active page
 rodney stop               # Shut down Chrome
@@ -403,7 +404,7 @@ The tool uses the [rod](https://github.com/go-rod/rod) Go library which communic
 
 | Command | Arguments | Description |
 |---|---|---|
-| `start` | `[--show] [--insecure\|-k]` | Launch Chrome (headless by default, `--show` for visible) |
+| `start` | `[--show] [--insecure\|-k] [--fake-media]` | Launch Chrome (headless by default, `--show` for visible) |
 | `connect` | `<host:port>` | Connect to existing Chrome on remote debug port |
 | `stop` | | Shut down Chrome |
 | `status` | | Show browser status |

--- a/main.go
+++ b/main.go
@@ -320,12 +320,15 @@ func withPage() (*State, *rod.Browser, *rod.Page) {
 
 func cmdStart(args []string) {
 	ignoreCertErrors := false
+	fakeMedia := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--insecure", "-k":
 			ignoreCertErrors = true
+		case "--fake-media":
+			fakeMedia = true
 		default:
-			fatal("unknown flag: %s\nusage: rodney start [--insecure]", args[i])
+			fatal("unknown flag: %s\nusage: rodney start [--insecure] [--fake-media]", args[i])
 		}
 	}
 
@@ -403,6 +406,11 @@ func cmdStart(args []string) {
 
 	if ignoreCertErrors {
 		l.Set("ignore-certificate-errors")
+	}
+
+	if fakeMedia {
+		l.Set("use-fake-device-for-media-stream")
+		l.Set("use-fake-ui-for-media-stream")
 	}
 
 	debugURL := l.MustLaunch()


### PR DESCRIPTION
Added for myself, to avoid the browser dying when requesting microphone access.
Possibly not needed if https://github.com/simonw/rodney/pull/8 is merged.

Arguably a sensible default? Although possibly not in combination with `--show`?

No strong feelings here - feel free to ignore or suggest another approach. This is largely to make it work for my use case.