### PR TITLE
Skip single-process flag on macOS to prevent Chromium crashes

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -377,10 +378,15 @@ func cmdStart(args []string) {
 	l := launcher.New().
 		Set("no-sandbox").
 		Set("disable-gpu").
-		Set("single-process"). // Required for screenshots in gVisor/container environments
 		Leakless(false).        // Keep Chrome alive after CLI exits
 		UserDataDir(dataDir).
 		Headless(headless)
+
+	// single-process is required for screenshots in gVisor/container environments
+	// but crashes Chromium on complex sites on macOS
+	if runtime.GOOS != "darwin" {
+		l = l.Set("single-process")
+	}
 
 	// When in non-headless mode, make sure that we show the startup window immediately
 	// (instead of showing a window only after calling "rodney open")


### PR DESCRIPTION
The `--single-process` Chrome flag, required for screenshots in gVisor/container environments, causes Chromium to crash on macOS when navigating to complex sites (e.g. pages with Keycloak SSO, media permission checks). Simple sites and local dev servers work fine.

In single-process mode, all Chromium subsystems share one process. When any subsystem hits a fatal condition — such as a macOS TCC permission check (e.g. microphone) that can't display a prompt — it takes down the entire browser. In multi-process mode these crashes are isolated and recoverable.

Evidence from crash reports:
- `EXC_BREAKPOINT`/`SIGTRAP` on a thread queued for `com.apple.tcc.preflight.kTCCServiceMicrophone`
- `SIGABRT` in `CFBundleGetInfoDictionary` on `CrBrowserMain`
- Chromium 128.0.6568.0 (go-rod bundled revision 1321438)

This change only skips the flag on Darwin. Linux and Windows behavior is unchanged.