### PR TITLE
Add help note about suppressing output when inputting secrets

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -33,6 +33,11 @@ Interaction:
   rodney hover <selector>         Hover over an element
   rodney focus <selector>         Focus an element
 
+When using "rodney input" to fill a field with a secret from a keychain or
+credential store (e.g. macOS "security", 1Password "op", "pass", "vault"),
+redirect output so the secret is not printed back:
+  rodney input '#password' "$(security find-generic-password -w ...)" > /dev/null 2>&1
+
 Waiting:
   rodney wait <selector>          Wait for element to appear
   rodney waitload                 Wait for page load


### PR DESCRIPTION
## Summary

- Adds a short note to the `--help` text (in `help.txt`) advising users to redirect output to `/dev/null` when using `rodney input` with secrets from a keychain or credential store

This is especially relevant for LLM coding agents that use `rodney input` to fill password fields — without the redirect, the secret value gets captured in shell tool output and leaked into the conversation context.

## Purpose

To use rodney to test changes to systems behind interactive authentication, and allow the human to stay out of the loop, it can be important to allow an agent to authenticate on its own. We can use keychain tools like `security` to effect this, but it then becomes important to ensure that password doesn't get leaked into context.

## Example

```bash
# Secret stays hidden
rodney input '#password' "$(security find-generic-password -w ...)" > /dev/null 2>&1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)