### PR TITLE
Fix screenshot timing out when the target page is not in the foreground

### DIFF
--- a/capture_test.go
+++ b/capture_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+)
+
+// visibilityState reports what the page thinks its own visibility is, which is
+// how Chromium exposes whether a target is the foreground one.
+func visibilityState(t *testing.T, p *rod.Page) string {
+	t.Helper()
+	res, err := p.Eval("() => document.visibilityState")
+	if err != nil {
+		t.Fatalf("reading visibilityState: %v", err)
+	}
+	return res.Value.String()
+}
+
+// openTwoPages returns a page that has been pushed into the background by a
+// second one, plus that second page.
+func openTwoPages(t *testing.T) (background, foreground *rod.Page) {
+	t.Helper()
+	background = env.browser.MustPage(env.server.URL)
+	t.Cleanup(func() { background.MustClose() })
+	foreground = env.browser.MustPage(env.server.URL + "/form")
+	t.Cleanup(func() { foreground.MustClose() })
+
+	if got := visibilityState(t, background); got != "hidden" {
+		t.Fatalf("first page visibilityState = %q, want %q -- opening a second page "+
+			"is supposed to background the first, so this test proves nothing", got, "hidden")
+	}
+	return background, foreground
+}
+
+func TestBringToFront_MakesTargetVisible(t *testing.T) {
+	background, _ := openTwoPages(t)
+
+	bringToFront(background)
+
+	if got := visibilityState(t, background); got != "visible" {
+		t.Errorf("visibilityState = %q after bringToFront, want %q", got, "visible")
+	}
+}
+
+// The regression. A backgrounded target has no compositor producing frames, so
+// Page.captureScreenshot waits for one that never arrives and the CLI reports
+// "screenshot failed: context deadline exceeded". Without the bringToFront call
+// this test hangs until the timeout below and fails.
+func TestScreenshot_BackgroundedTargetDoesNotHang(t *testing.T) {
+	background, _ := openTwoPages(t)
+
+	bringToFront(background)
+
+	data, err := background.Timeout(20*time.Second).Screenshot(true, nil)
+	if err != nil {
+		t.Fatalf("full-page screenshot of a backgrounded target: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("screenshot returned no data")
+	}
+}
+
+// Element capture goes through rod's visibility/stability wait as well, where a
+// hidden target hangs for far longer than the screenshot deadline.
+func TestScreenshotEl_BackgroundedTargetDoesNotHang(t *testing.T) {
+	background, _ := openTwoPages(t)
+
+	bringToFront(background)
+
+	// rod's element capture ignores the page timeout while it waits for the
+	// element to become stable, and on a hidden target that wait outlives the
+	// whole test binary. Bound it here so a regression fails this one test
+	// instead of panicking the suite ten minutes later.
+	type result struct {
+		data []byte
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		el, err := background.Element("h1")
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		data, err := el.Screenshot(proto.PageCaptureScreenshotFormatPng, 0)
+		done <- result{data: data, err: err}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("element screenshot of a backgrounded target: %v", r.err)
+		}
+		if len(r.data) == 0 {
+			t.Error("element screenshot returned no data")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("element screenshot of a backgrounded target did not finish within 30s")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -334,6 +334,27 @@ func withPage() (*State, *rod.Browser, *rod.Page) {
 	return s, browser, page
 }
 
+// bringToFront makes page the browser's foreground target.
+//
+// rodney's "active page" is only an index in its own state file; the browser is
+// never told about it, so after "rodney page N" the foreground target is still
+// whichever one was opened last. DOM and JS commands do not care -- they read a
+// hidden target perfectly well -- but a backgrounded target has no compositor
+// producing frames, and Page.captureScreenshot simply waits for one that never
+// arrives until the context deadline expires:
+//
+//	error: screenshot failed: context deadline exceeded
+//
+// So every command that captures pixels has to raise its target first.
+//
+// Errors are deliberately ignored. Activation failing means the target or the
+// browser is gone, in which case the capture that follows reports the real
+// problem; turning that into an error here would only replace a good message
+// with a worse one, and would risk failing captures that would have worked.
+func bringToFront(page *rod.Page) {
+	_, _ = page.Activate()
+}
+
 // --- Commands ---
 
 // parseStartArgs parses the flags for the "start" command.
@@ -1150,6 +1171,7 @@ func cmdScreenshot(args []string) {
 	}
 
 	_, _, page := withPage()
+	bringToFront(page)
 
 	// Set viewport size
 	viewportHeight := *height
@@ -1184,6 +1206,7 @@ func cmdScreenshotEl(args []string) {
 		file = args[1]
 	}
 	_, _, page := withPage()
+	bringToFront(page)
 	el, err := page.Element(args[0])
 	if err != nil {
 		fatal("element not found: %v", err)
@@ -1252,6 +1275,9 @@ func cmdPage(args []string) {
 	if err := saveState(s); err != nil {
 		fatal("failed to save state: %v", err)
 	}
+	// Switch the browser too, not just our own index, so the page a caller just
+	// selected is the one being rendered.
+	bringToFront(pages[idx])
 	info, _ := pages[idx].Info()
 	if info != nil {
 		fmt.Printf("Switched to [%d] %s - %s\n", idx, info.Title, info.URL)


### PR DESCRIPTION
## Summary

`rodney screenshot` fails with `context deadline exceeded` whenever the page it
targets is not the browser's **foreground** target:

```bash
rodney open https://www.epicured.com/
rodney screenshot a.png      # works
rodney newpage <other url>
rodney page 1                # switch back
rodney url                   # correct page
rodney screenshot b.png      # error: screenshot failed: context deadline exceeded
```

## Root cause

rodney's "active page" is only an index in its own state file (`active_page`).
The browser is never told about it, so after `rodney page N` the foreground
target is still whichever page was opened last. `cmdPage` wrote the index and
nothing else — `Activate`/`bringToFront` appeared nowhere in the codebase.

DOM and JS commands don't care: they read a hidden target perfectly well, which
is why `url`, `js` and `text` all keep reporting the switched-to page correctly.
But a backgrounded target has no compositor producing frames, so
`Page.captureScreenshot` waits for one that never arrives.

**Page size is a red herring.** Measured: a heavy page captures in **0.23s** when
it is in the foreground, while a backgrounded `example.com` times out after 30s.
What decides it is foreground, not weight — the reported "heavy page" correlation
was a confound, because the heavy page happened to be the backgrounded one.

`screenshot-el` is affected too, and worse: rod's element stability wait ignores
the page timeout, so a hidden target hangs for **over eight minutes** rather than
30 seconds. `pdf` is unaffected — `printToPDF` re-renders and needs no frame.

## Fix

- `cmdPage` switches the browser as well as the index, so the page a caller just
  selected is the one being rendered.
- `cmdScreenshot` and `cmdScreenshotEl` raise their target before capturing, so a
  state file that has drifted out of sync with the browser (page opened by
  `window.open`, foreground page closed) cannot wedge a capture.

## Not a regression from the crash fixes

It reproduces identically on the pre-crash-fix binary with `--single-process` and
old headless, so it is pre-existing and unrelated to #54 or to extension mode.

## Verification

| scenario | before | after |
|---|---|---|
| 1 page, heavy foreground | 1s OK | 1s OK |
| 2 pages, heavy backgrounded | **30s timeout** | 1s, 5.6 MB |
| 2 pages, light backgrounded | **30s timeout** | 0s OK |
| `screenshot-el`, backgrounded | **>8 min hang** | 0s OK |
| reported repro, extension mode | fails at step b | all three captures OK |

Three regression tests added. Verified they genuinely catch the bug: with
`bringToFront` neutered they fail in 51s total (`0.08s` / `20.06s` / `30.07s`);
with the fix they pass in 3.4s. The element test bounds its own wait so a
regression fails that one test rather than panicking the suite ten minutes later,
which is what an unbounded version did.

`go build`, `go vet` and the full `go test ./...` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
